### PR TITLE
[Dev] Upgrade to v 9.6.20

### DIFF
--- a/postgresql@9.6.rb
+++ b/postgresql@9.6.rb
@@ -43,6 +43,7 @@ class PostgresqlAT96 < Formula
       --with-perl
       --with-python
       --with-tcl
+      --without-perl
       XML2_CONFIG=:
     ]
 

--- a/postgresql@9.6.rb
+++ b/postgresql@9.6.rb
@@ -40,7 +40,6 @@ class PostgresqlAT96 < Formula
       --with-openssl
       --with-uuid=e2fs
       --with-pam
-      --with-perl
       --with-python
       --with-tcl
       --without-perl

--- a/postgresql@9.6.rb
+++ b/postgresql@9.6.rb
@@ -1,7 +1,7 @@
 class PostgresqlAT96 < Formula
   desc "Relational database management system"
   homepage "https://www.postgresql.org/"
-  version = "9.6.3"
+  version = "9.6.20"
   url "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
   sha256 "1645b3736901f6d854e695a937389e68ff2066ce0cde9d73919d6ab7c995b9c6"
 


### PR DESCRIPTION
psql 9.6.3 is failing on macos catalina
```
$ brew install producthunt/postgresql/postgresql@9.6
==> Installing postgresql@9.6 from producthunt/postgresql
==> Downloading https://ftp.postgresql.org/pub/source/v9.6.3/postgresql-9.6.3.tar.bz2
######################################################################## 100.0%
==> ./configure --prefix=/usr/local/Cellar/postgresql@9.6/9.6.3 --enable-dtrace --enable-nls --with-bonjour --with-gssapi --with-ldap --with-libxml --with-libxslt --with-openssl --with-uuid=e2fs --with-pam --with-python --with-tcl --without-perl XML2_CONFIG=: --wit
Last 15 lines from /Users/zyqxd/Library/Logs/Homebrew/postgresql@9.6/01.configure:
checking for opterr... yes
checking for optreset... yes
checking for strtoll... yes
checking for strtoull... yes
checking for rl_completion_append_character... yes
checking for rl_completion_matches... yes
checking for rl_filename_completion_function... yes
checking for rl_reset_screen_size... yes
checking for append_history... yes
checking for history_truncate_file... yes
checking test program... ok
checking whether snprintf supports argument control... yes
checking whether long int is 64 bits... no
checking whether long long int is 64 bits... no
**configure: error: Cannot find a working 64-bit integer type.**

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/producthunt/homebrew-postgresql/issues
```

9.6.20 seems to solve this issue